### PR TITLE
Rely on .mocharc.json for `vscode test extension`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,4 @@
 {
   "mochaExplorer.files": "tests/**/*.ts",
-  "mochaExplorer.require": "ts-node/register",
-  "mochaExplorer.ui": "tdd",
   "typescript.tsdk": "node_modules/typescript/lib"
 }


### PR DESCRIPTION
This feature is supported by default in `vscode-mocha-test-adapter`
Refer: https://github.com/hbenl/vscode-mocha-test-adapter/issues/72#issuecomment-557177133
Closes #6